### PR TITLE
Fix runServerTests

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 task runServerTests {
     group = "application"
 }
-runServerTests.dependsOn testClasses
+runServerTests.dependsOn test
 
 //Both karma and junit tests
 task runAllTests {
@@ -37,6 +37,6 @@ task buildExecutable {
 }
 buildExecutable.dependsOn(build)
 
-runAllTests.dependsOn test
+runAllTests.dependsOn check
 
-test.dependsOn(":client:runClientTests")
+check.dependsOn(":client:runClientTests")


### PR DESCRIPTION
This makes the `runServerTests` task actually run server tests. Now the `test` task only run server tests but the `check` task will run client tests and server tests (the `check` task being what travis uses).

This closes #9.