### PR TITLE
Fix use of mat-list again, but differently

### DIFF
--- a/client/src/app/users/user.component.html
+++ b/client/src/app/users/user.component.html
@@ -1,7 +1,5 @@
-<div *ngIf="user" #users>
-    <ul mat-list>
-        <li mat-list-item>Name: {{ user.name }}</li>
-        <li mat-list-item>Age: {{ user.age }}</li>
-        <li mat-list-item>Company: {{ user.company }}</li>
-    </ul>
-</div>
+<mat-list *ngIf="user" #users>
+    <mat-list-item>Name: {{ user.name }}</mat-list-item>
+    <mat-list-item>Age: {{ user.age }}</mat-list-item>
+    <mat-list-item>Company: {{ user.company }}</mat-list-item>
+</mat-list>

--- a/client/src/app/users/user.component.spec.ts
+++ b/client/src/app/users/user.component.spec.ts
@@ -3,6 +3,7 @@ import {User} from './user';
 import {UserComponent} from './user.component';
 import {UserListService} from './user-list.service';
 import {Observable} from 'rxjs/Observable';
+import {CustomModule} from "../custom.module";
 
 describe('User component', () => {
 
@@ -42,6 +43,7 @@ describe('User component', () => {
         };
 
         TestBed.configureTestingModule({
+            imports: [CustomModule],
             declarations: [UserComponent],
             providers: [{provide: UserListService, useValue: userListServiceStub}]
         });


### PR DESCRIPTION
This commit updates the code in user.component.html to use an Angular Material Design mat-list and updates the karma tests that check that the world still works. I think this is a more appropriate way to use mat-list than my most recent commit before this. The problem I had that the previous commit didn't recognize or fix was that the karma tests were not working with mat-list. Importing CustomModule fixes that.