### PR TITLE
Update node version

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 node {
-  version = '6.11.2'
+  version = '10.15.1'
   download = true
   workDir = file("${project.projectDir}/node")
   yarnWorkDir = file("${project.projectDir}/yarn")

--- a/client/e2e/user-list.e2e-spec.ts
+++ b/client/e2e/user-list.e2e-spec.ts
@@ -13,7 +13,8 @@ browser.driver.controlFlow().execute = function () {
 
     // queue 100ms wait between test
     // This delay is only put here so that you can watch the browser do its thing.
-    // If you're tired of it taking long you can remove this call
+    // If you're tired of it taking long you can remove this call or change the delay
+    // to something smaller (even 0).
     origFn.call(browser.driver.controlFlow(), () => {
         return protractor.promise.delayed(100);
     });


### PR DESCRIPTION
We were using a *very* old version of `node` (v6.11.2) and need to
update that to be able to use more recent version of important tools
like Angular CLI.