### PR TITLE
Work around problem generated by upgrading Spark

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -12,7 +12,6 @@ mainClassName = 'umm3601.Server'
 
 dependencies {
   compile 'com.sparkjava:spark-core:2.7.2'
-  compile 'com.sparkjava:spark-debug-tools:0.5'
   compile 'org.slf4j:slf4j-simple:1.7.26'
   compile 'com.google.code.gson:gson:2.8.5'
   compile 'org.mongodb:mongodb-driver:3.10.1'

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -8,7 +8,6 @@ import umm3601.user.UserController;
 import umm3601.user.UserRequestHandler;
 
 import static spark.Spark.*;
-import static spark.debug.DebugScreen.enableDebugScreen;
 
 public class Server {
   private static final String userDatabaseName = "dev";
@@ -24,7 +23,6 @@ public class Server {
 
     //Configure Spark
     port(serverPort);
-    enableDebugScreen();
 
     // Specify where assets like images will be "stored"
     staticFiles.location("/public");


### PR DESCRIPTION
Upgrading Spark past v2.7.0 has failed when we tried to run the server
using a workaround posted on the Spark repo. [See lab 2 for more.](https://github.com/UMM-CSci-3601/3601-lab2_client-server/pull/58).

This does fix the problem, but at the expense of having to turn off
our use of the debugging tools.